### PR TITLE
add a check to see if competition_stage, stadium, and referee columns exist in matches dataframe.

### DIFF
--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -37,9 +37,10 @@ def matches(
         for col in ["season", "home_team", "away_team"]:
             matches[col] = matches[col].apply(lambda c: c[f"{col}_name"])
         for col in ["competition_stage", "stadium", "referee"]:
-            matches[col] = matches[col].apply(
-                lambda x: x["name"] if not pd.isna(x) else x
-            )
+            if col in matches.columns:
+                matches[col] = matches[col].apply(
+                    lambda x: x["name"] if not pd.isna(x) else x
+                )
         metadata = matches.pop("metadata")
         for k in ["data_version", "shot_fidelity_version", "xy_fidelity_version"]:
             matches[k] = metadata.apply(lambda x: x.get(k))

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -28,6 +28,15 @@ class TestBaseGetters(TestCase):
         matches = sb.matches(competition_id=43, season_id=3, creds={})
         self.assertIsInstance(matches, pd.DataFrame)
 
+        matches = sb.matches(competition_id=2, season_id=44)
+        self.assertIsInstance(matches, pd.DataFrame)
+
+        matches = sb.matches(competition_id=2, season_id=44, fmt="json")
+        self.assertIsInstance(matches, dict)
+
+        matches = sb.matches(competition_id=2, season_id=44, creds={})
+        self.assertIsInstance(matches, pd.DataFrame)
+
     def test_lineups(self):
         lineups = sb.lineups(match_id=7562)
         self.assertIsInstance(lineups, dict)


### PR DESCRIPTION
I've noticed that the 2003/04 PL matches file ([data/matches/2/44.json](https://github.com/statsbomb/open-data/blob/master/data/matches/2/44.json)) in statsbomb-opendata has no data for stadiums, which causes this program to raise a KeyError exception when downloading the matches file. I've raised the data collection issue on the opendata repository, but given that its such a minor part of the matches file, I've added a check to allow for the system to return the dataframe sans the stadium column if it doesn't exist.