### PR TITLE
Removed cashier cache in favor of functools.lru_cache

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(
     author_email="support@statsbombservices.com",
     packages=["statsbombpy"],
     install_requires=[
+        "joblib",
         "inflect",
         "nose2",
         "pandas",

--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,6 @@ setup(
     author_email="support@statsbombservices.com",
     packages=["statsbombpy"],
     install_requires=[
-        "cashier",
         "inflect",
         "nose2",
         "pandas",

--- a/statsbombpy/helpers.py
+++ b/statsbombpy/helpers.py
@@ -1,10 +1,8 @@
 from collections import defaultdict
+from functools import lru_cache
 
 import inflect
 import pandas as pd
-
-from cashier import cache
-
 
 def flatten_event(event, flatten_attrs):
     if flatten_attrs:
@@ -49,7 +47,7 @@ def reduce_events(all_events: dict, fmt: str) -> dict:
 
 
 engine = inflect.engine()
-@cache()
+@lru_cache
 def pluralize(word):
     word = engine.plural(word)
     word = word.replace("*", "")

--- a/statsbombpy/helpers.py
+++ b/statsbombpy/helpers.py
@@ -1,5 +1,5 @@
 from collections import defaultdict
-from functools import lru_cache
+from joblib import Memory
 
 import inflect
 import pandas as pd
@@ -47,7 +47,11 @@ def reduce_events(all_events: dict, fmt: str) -> dict:
 
 
 engine = inflect.engine()
-@lru_cache
+
+cachedir = '.cache/'
+memory = Memory(cachedir, verbose=0)
+
+@memory.cache
 def pluralize(word):
     word = engine.plural(word)
     word = word.replace("*", "")


### PR DESCRIPTION
Executing `import sb from statsbompy` would result in an error using Python 3.7 and up, as `dummy_thread` which is used by `cashier` has been deprecated. Fortunately, `functools.lru_cache` (included since Python 3.2) provides the same functionality as the `@cache` decorator from cashier and allows us to avoid using cashier altogether.