### PR TITLE
Competition events fix

### DIFF
--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -96,12 +96,12 @@ def competition_events(
     creds: dict = DEFAULT_CREDS,
 ) -> (pd.DataFrame, dict):
 
-    c = competitions(creds)[country, division, season, gender]
+    c = competitions(creds=creds, fmt='dict')[country, division, season, gender]
 
     events_call = partial(events, fmt="json", creds=creds,)
     with Pool(PARALLELL_CALLS_NUM) as p:
         matches_events = p.map(
-            events_call, matches(c["competition_id"], c["season_id"], creds)
+            events_call, matches(c["competition_id"], c["season_id"], fmt='dict', creds=creds)
         )
         matches_events = map(
             lambda events: filter_and_group_events(

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -26,7 +26,7 @@ def matches(
     competition_id: int, season_id: int, fmt="dataframe", creds: dict = DEFAULT_CREDS
 ):
     if api_client.has_auth(creds) is True:
-        matches = api_client.matches(competition_id, season_id, creds)
+        matches = api_client.matches(competition_id, season_id, creds=creds)
     else:
         matches = public.matches(competition_id, season_id)
     if fmt == "dataframe":
@@ -49,7 +49,7 @@ def matches(
 
 def lineups(match_id, fmt="dataframe", creds: dict = DEFAULT_CREDS):
     if api_client.has_auth(creds) is True:
-        lineups = api_client.lineups(match_id, creds)
+        lineups = api_client.lineups(match_id, creds=creds)
     else:
         lineups = public.lineups(match_id)
     if fmt == "dataframe":
@@ -72,7 +72,7 @@ def events(
 ) -> (pd.DataFrame, dict):
 
     if api_client.has_auth(creds) is True:
-        events = api_client.events(match_id, creds)
+        events = api_client.events(match_id, creds=creds)
     else:
         events = public.events(match_id)
 

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -96,12 +96,17 @@ def competition_events(
     creds: dict = DEFAULT_CREDS,
 ) -> (pd.DataFrame, dict):
 
-    c = competitions(creds=creds, fmt='dict')[country, division, season, gender]
+    c = competitions(creds=creds, fmt="dict")[country, division, season, gender]
 
-    events_call = partial(events, fmt="json", creds=creds,)
+    events_call = partial(
+        events,
+        fmt="json",
+        creds=creds,
+    )
     with Pool(PARALLELL_CALLS_NUM) as p:
         matches_events = p.map(
-            events_call, matches(c["competition_id"], c["season_id"], fmt='dict', creds=creds)
+            events_call,
+            matches(c["competition_id"], c["season_id"], fmt="dict", creds=creds),
         )
         matches_events = map(
             lambda events: filter_and_group_events(

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -72,22 +72,25 @@ class TestEventGetters(TestCase):
 
     def test_competition_events(self):
         events = sb.competition_events(
-            country="England", division="FA Cup", season="2019/2020", gender="male"
+            country="Europe",
+            division="Champions League",
+            season="2018/2019",
+            gender="male",
         )
         self.assertIsInstance(events, pd.DataFrame)
 
         events = sb.competition_events(
-            country="England",
-            division="FA Cup",
-            season="2019/2020",
+            country="Europe",
+            division="Champions League",
+            season="2018/2019",
             split=True,
         )
         self.assertIsInstance(events["shots"], pd.DataFrame)
 
         events = sb.competition_events(
-            country="England",
-            division="FA Cup",
-            season="2019/2020",
+            country="Europe",
+            division="Champions League",
+            season="2018/2019",
             fmt="json",
         )
 


### PR DESCRIPTION
Fixed bug in `competition_events`. 

`competitions` and `matches` were being called with creds was being passed as a positional argument in the wrong position, and output from these was assumed to be a dict, but dataframes were being returned. The function calls to `competitions` and `matches` within `competition_events` have been fixed to explicitly ask the returned objects to be dicts (using the `fmt` argument) and are now passing creds as a kwarg.