### PR TITLE
utilities to pull 360 frames from the API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1186,6 +1186,83 @@ grouped_events["dribbles"]
   </tbody>
 </table>
 
+### 360 Frames
+
+If you have credentials to an account with access to 360 data, you can access the frames for a match or a competition
+
+```
+match_frames = sb.frames(match_id=3772072, fmt='dataframe')
+comp_frames = sb.competition_frames(
+    country="Germany",
+    division= "1. Bundesliga",
+    season="2019/2020"
+)
+match_frames
+```
+
+<table border=\"1\" class=\"dataframe\">
+  <thead>
+    <tr style=\"text-align: right;\">
+      <th></th>
+      <th>teammate</th>
+      <th>actor</th>
+      <th>keeper</th>
+      <th>location</th>
+      <th>id</th>
+      <th>visible_area</th>
+    </tr>
+  </thead>
+  <tbody>
+    <tr>
+      <th>0</th>
+      <td>True</td>
+      <td>False</td>
+      <td>False</td>
+      <td>[39.27561, 34.34118]</td>
+      <td>ca3c2fcb-e578-4103-a2b6-3c3da50a0009</td>
+      <td>[0.0, 80.0, 0.0, 64.3063432537811, 38.6449675910462, 0.0, 84.2004689919974, 0.0, 120.0, 53.0370178246748, 120.0, 80.0, 0.0, 80.0]</td>
+    </tr>
+    <tr>
+      <th>1</th>
+      <td>True</td>
+      <td>False</td>
+      <td>False</td>
+      <td>[45.01009, 22.54314]</td>
+      <td>ca3c2fcb-e578-4103-a2b6-3c3da50a0009</td>
+      <td>[0.0, 80.0, 0.0, 64.3063432537811, 38.6449675910462, 0.0, 84.2004689919974, 0.0, 120.0, 53.0370178246748, 120.0, 80.0, 0.0, 80.0]</td>
+    </tr>
+    <tr>
+      <th>2</th>
+      <td>True</td>
+      <td>False</td>
+      <td>False</td>
+      <td>[46.438095, 51.300377]</td>
+      <td>ca3c2fcb-e578-4103-a2b6-3c3da50a0009</td>
+      <td>[0.0, 80.0, 0.0, 64.3063432537811, 38.6449675910462, 0.0, 84.2004689919974, 0.0, 120.0, 53.0370178246748, 120.0, 80.0, 0.0, 80.0]</td>
+    </tr>
+    <tr>
+      <th>3</th>
+      <td>True</td>
+      <td>False</td>
+      <td>False</td>
+      <td>[53.26781, 30.843254]</td>
+      <td>ca3c2fcb-e578-4103-a2b6-3c3da50a0009</td>
+      <td>[0.0, 80.0, 0.0, 64.3063432537811, 38.6449675910462, 0.0, 84.2004689919974, 0.0, 120.0, 53.0370178246748, 120.0, 80.0, 0.0, 80.0]</td>
+    </tr>
+    <tr>
+      <th>4</th>
+      <td>True</td>
+      <td>False</td>
+      <td>False</td>
+      <td>[55.60041, 10.39319]</td>
+      <td>ca3c2fcb-e578-4103-a2b6-3c3da50a0009</td>
+      <td>[0.0, 80.0, 0.0, 64.3063432537811, 38.6449675910462, 0.0, 84.2004689919974, 0.0, 120.0, 53.0370178246748, 120.0, 80.0, 0.0, 80.0]</td>
+    </tr>
+  </tbody>
+</table>
+
+
+
 
 ### Raw Files
 Alternatively, entities can be accessed as python dictionaries serving as an interface to raw jsons and without performing any preprocessing
@@ -1206,4 +1283,15 @@ sb.competition_events(
     gender="male",
     fmt="dict"
 )
+
+sb.frames(303299, fmt="dict")
+
+sb.competition_frames(
+    country="Germany",
+    division= "1. Bundesliga",
+    season="2019/2020",
+    gender="male",
+    fmt="dict"
+)
+
 ```

--- a/README.md
+++ b/README.md
@@ -1284,12 +1284,12 @@ sb.competition_events(
     fmt="dict"
 )
 
-sb.frames(303299, fmt="dict")
+sb.frames(3772072, fmt="dict")
 
 sb.competition_frames(
     country="Germany",
     division= "1. Bundesliga",
-    season="2019/2020",
+    season="2021/2022",
     gender="male",
     fmt="dict"
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.0.1",
+    version="1.1.0",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.0",
+    version="1.0.1",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/api_client.py
+++ b/statsbombpy/api_client.py
@@ -1,6 +1,3 @@
-import os
-
-import pandas as pd
 import requests as req
 
 from requests_cache import install_cache
@@ -63,3 +60,8 @@ def events(match_id: int, creds: dict) -> dict:
     events = ents.events(events, match_id)
     return events
 
+
+def frames(match_id: int, creds: dict) -> dict:
+    url = f"{HOSTNAME}/api/{VERSIONS['360-frames']}/360-frames/{match_id}"
+    frames = get_resource(url, creds)
+    return frames

--- a/statsbombpy/config.py
+++ b/statsbombpy/config.py
@@ -18,5 +18,10 @@ OPEN_DATA_PATHS = {
 
 PARALLELL_CALLS_NUM = 4
 
-VERSIONS = {"competitions": "v2", "matches": "v3", "lineups": "v2", "events": "v5"}
-
+VERSIONS = {
+    "competitions": "v2",
+    "matches": "v3",
+    "lineups": "v2",
+    "events": "v5",
+    "360-frames": "v1",
+}

--- a/statsbombpy/entities.py
+++ b/statsbombpy/entities.py
@@ -1,34 +1,34 @@
 def competitions(competitions: list) -> dict:
     competitions_ = {}
-    for c in competitions:
+    for comp in competitions:
         competitions_[
             (
-                c["country_name"],
-                c["competition_name"],
-                c["season_name"],
-                c["competition_gender"],
+                comp["country_name"],
+                comp["competition_name"],
+                comp["season_name"],
+                comp["competition_gender"],
             )
-        ] = c
+        ] = comp
     return competitions_
 
 
 def matches(matches: list) -> dict:
     matches_ = {
-        m["match_id"]: m
-        for m in matches
-        if m["match_status"] == "available"
+        match["match_id"]: match
+        for match in matches
+        if match["match_status"] == "available"
     }
     return matches_
 
 
 def lineups(lineups: list) -> dict:
-    lineups_ = {l["team_id"]: l for l in lineups}
+    lineups_ = {lineup["team_id"]: lineup for lineup in lineups}
     return lineups_
 
 
 def events(events: list, match_id: int) -> dict:
     events_ = {}
-    for e in events:
-        e["match_id"] = match_id
-        events_[e["id"]] = e
+    for ev in events:
+        ev["match_id"] = match_id
+        events_[ev["id"]] = ev
     return events_

--- a/statsbombpy/helpers.py
+++ b/statsbombpy/helpers.py
@@ -4,9 +4,10 @@ from joblib import Memory
 import inflect
 import pandas as pd
 
+
 def flatten_event(event, flatten_attrs):
     if flatten_attrs:
-        ev_type = event["type"]["name"].lower().replace(" ", "_").replace("*","")
+        ev_type = event["type"]["name"].lower().replace(" ", "_").replace("*", "")
         ev_type = ev_type if event["type"]["name"] != "Goal Keeper" else "goalkeeper"
         if ev_type in event:
             for k, v in event[ev_type].items():
@@ -48,8 +49,9 @@ def reduce_events(all_events: dict, fmt: str) -> dict:
 
 engine = inflect.engine()
 
-cachedir = '.cache/'
+cachedir = ".cache/"
 memory = Memory(cachedir, verbose=0)
+
 
 @memory.cache
 def pluralize(word):

--- a/statsbombpy/public.py
+++ b/statsbombpy/public.py
@@ -1,4 +1,5 @@
 import requests as req
+import warnings
 
 import statsbombpy.entities as ents
 
@@ -31,3 +32,9 @@ def events(match_id: int) -> dict:
     events = req.get(OPEN_DATA_PATHS["events"].format(match_id=match_id)).json()
     events = ents.events(events, match_id)
     return events
+
+
+def frames(match_id: int) -> dict:
+    frames = {}
+    warnings.warn("There is currently no open 360 data, returning empty dict")
+    return frames

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -124,14 +124,19 @@ def competition_events(
 
 
 def frames(
-    match_id, fmt="dataframe", creds: dict = DEFAULT_CREDS
+    match_id: int,
+    fmt: str = "dataframe",
+    creds: dict = DEFAULT_CREDS,
 ) -> Union[pd.DataFrame, dict]:
     if api_client.has_auth(creds) is True:
         frames = api_client.frames(match_id, creds=creds)
     else:
         frames = public.frames(match_id)
     if fmt == "dataframe":
-        frames = pd.DataFrame(frames)
+        frames = pd.json_normalize(
+            frames, "freeze_frame", ["event_uuid", "visible_area"]
+        )
+        frames = frames.rename(columns={"event_uuid": "id"})
     return frames
 
 
@@ -159,7 +164,7 @@ def competition_frames(
 
     if fmt == "dataframe":
         competition_frames = pd.concat(
-            [pd.DataFrame(frame) for frame in frames],
+            [pd.DataFrame(frame) for frame in competition_frames],
             axis=0,
             ignore_index=True,
             sort=True,

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -1,5 +1,3 @@
-import os
-
 import pandas as pd
 
 from unittest import TestCase, main
@@ -93,6 +91,37 @@ class TestEventGetters(TestCase):
             season="2018/2019",
             fmt="json",
         )
+
+
+class TestFrameGetters(TestCase):
+    def test_frames(self):
+        frames = sb.frames(match_id=3764302)
+        self.assertIsInstance(frames, pd.DataFrame)
+
+        frames = sb.frames(match_id=3764302, fmt="json")
+        self.assertIsInstance(frames, dict)
+
+        frames = sb.events(match_id=3764302, creds={})
+        self.assertIsInstance(frames, pd.DataFrame)
+        self.assertTrue(len(frames) == 0)
+
+    def test_competition_frames(self):
+        frames = sb.competition_frames(
+            country="Germany",
+            division="1. Bundesliga",
+            season="2020/2021",
+            gender="male",
+        )
+        self.assertIsInstance(frames, pd.DataFrame)
+
+        frames = sb.competition_frames(
+            country="Germany",
+            division="1. Bundesliga",
+            season="2020/2021",
+            gender="male",
+            fmt="json",
+        )
+        self.assertIsInstance(frames, dict)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`sb.frames` returns the json as-is from the API, or a dataframe with columns `event_uuid`, `visible_area` (list of vertices), `freeze_frame` (dict).

`sb.competition_frames` pulls all 360 frames for a comp and returns either a list of dicts (one per match) or a dataframe with all FFs.

if the wrong creds are supplied `frames` returns an empty dict/dataframe with a warning.

mirrored the tests for other functions and applied black formatting/removed some unused imports/generally cleaned up some stuff too.