### PR TITLE
Add player and team ids to events function

### DIFF
--- a/statsbombpy/helpers.py
+++ b/statsbombpy/helpers.py
@@ -16,11 +16,9 @@ def flatten_event(event, flatten_attrs):
 
     for k, v in event.copy().items():
         if isinstance(v, dict) and "name" in v:
+            event[k] = v["name"]
             if k in ['possession_team', 'player']:
-                event[k] = v["name"]
                 event[f"{k}_id"] = v['id']
-            else:
-                event[k] = v["name"]
     return event
 
 

--- a/statsbombpy/helpers.py
+++ b/statsbombpy/helpers.py
@@ -14,9 +14,13 @@ def flatten_event(event, flatten_attrs):
                 event[f"{ev_type}_{k}"] = v
             del event[ev_type]
 
-    for k, v in event.items():
+    for k, v in event.copy().items():
         if isinstance(v, dict) and "name" in v:
-            event[k] = v["name"]
+            if k in ['possession_team', 'player']:
+                event[k] = v["name"]
+                event[f"{k}_id"] = v['id']
+            else:
+                event[k] = v["name"]
     return event
 
 


### PR DESCRIPTION
`sb.events()` and therefore `sb.competition_events()` return event data with no player ids as pointed out by a support query.

Upon inspection, we appear to remove all ids relating to event tags. A simple fix would be to add them all but that results in ~35 extra columns.

Instead, this PR only adds the id if it's for the player or the possession team hence the resulting table has team and player ids.