### PR TITLE
Fix frames test to work with modified frames function

### DIFF
--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -101,8 +101,8 @@ class TestFrameGetters(TestCase):
         frames = sb.frames(match_id=3764302, fmt="json")
         self.assertIsInstance(frames, dict)
 
-        frames = sb.events(match_id=3764302, creds={})
-        self.assertRaises(Exception, frames)
+        with self.assertRaises(Exception):
+            sb.events(match_id=3764302, creds={})
 
     def test_competition_frames(self):
         frames = sb.competition_frames(


### PR DESCRIPTION
The test for the `sb.frames()` function is wrong. This fixes it. 