### PR TITLE
Add free 360 functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1188,8 +1188,6 @@ grouped_events["dribbles"]
 
 ### 360 Frames
 
-If you have credentials to an account with access to 360 data, you can access the frames for a match or a competition
-
 ```
 match_frames = sb.frames(match_id=3772072, fmt='dataframe')
 comp_frames = sb.competition_frames(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.2.0",
+    version="1.3.0",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/api_client.py
+++ b/statsbombpy/api_client.py
@@ -64,6 +64,7 @@ def events(match_id: int, creds: dict) -> dict:
 def frames(match_id: int, creds: dict) -> dict:
     url = f"{HOSTNAME}/api/{VERSIONS['360-frames']}/360-frames/{match_id}"
     frames = get_resource(url, creds)
+    frames = ents.frames(frames, match_id)
     return frames
 
 

--- a/statsbombpy/config.py
+++ b/statsbombpy/config.py
@@ -14,6 +14,7 @@ OPEN_DATA_PATHS = {
     "matches": "https://raw.githubusercontent.com/statsbomb/open-data/master/data/matches/{competition_id}/{season_id}.json",
     "lineups": "https://raw.githubusercontent.com/statsbomb/open-data/master/data/lineups/{match_id}.json",
     "events": "https://raw.githubusercontent.com/statsbomb/open-data/master/data/events/{match_id}.json",
+    "frames": "https://raw.githubusercontent.com/statsbomb/open-data/master/data/three-sixty/{match_id}.json",
 }
 
 PARALLELL_CALLS_NUM = 4

--- a/statsbombpy/entities.py
+++ b/statsbombpy/entities.py
@@ -32,3 +32,8 @@ def events(events: list, match_id: int) -> dict:
         ev["match_id"] = match_id
         events_[ev["id"]] = ev
     return events_
+
+def frames(frames: list, match_id: int) -> list:
+    for fr in frames:
+        fr["match_id"] = match_id
+    return frames

--- a/statsbombpy/public.py
+++ b/statsbombpy/public.py
@@ -32,3 +32,8 @@ def events(match_id: int) -> dict:
     events = req.get(OPEN_DATA_PATHS["events"].format(match_id=match_id)).json()
     events = ents.events(events, match_id)
     return events
+
+def frames(match_id: int) -> dict:
+    frames = req.get(OPEN_DATA_PATHS["frames"].format(match_id=match_id)).json()
+    frames = ents.frames(frames, match_id)
+    return frames

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -132,10 +132,10 @@ def frames(
     if api_client.has_auth(creds) is True:
         frames = api_client.frames(match_id, creds=creds)
     else:
-        raise Exception("There is currently no open 360 data, please provide credentials")
+        frames = public.frames(match_id)
     if fmt == "dataframe":
         frames = pd.json_normalize(
-            frames, "freeze_frame", ["event_uuid", "visible_area"]
+            frames, "freeze_frame", ["event_uuid", "visible_area", "match_id"]
         )
         frames = frames.rename(columns={"event_uuid": "id"})
     return frames

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -99,28 +99,28 @@ class TestFrameGetters(TestCase):
         self.assertIsInstance(frames, pd.DataFrame)
 
         frames = sb.frames(match_id=3764302, fmt="json")
-        self.assertIsInstance(frames, dict)
+        self.assertIsInstance(frames, list)
 
-        with self.assertRaises(Exception):
-            sb.events(match_id=3764302, creds={})
+        frames = sb.frames(match_id=3788741, creds={})
+        self.assertIsInstance(frames, pd.DataFrame)
 
     def test_competition_frames(self):
         frames = sb.competition_frames(
-            country="Germany",
-            division="1. Bundesliga",
-            season="2020/2021",
+            country="Europe",
+            division="Champions League",
+            season="2021/2022",
             gender="male",
         )
         self.assertIsInstance(frames, pd.DataFrame)
 
         frames = sb.competition_frames(
-            country="Germany",
-            division="1. Bundesliga",
-            season="2020/2021",
+            country="Europe",
+            division="Champions League",
+            season="2021/2022",
             gender="male",
             fmt="json",
         )
-        self.assertIsInstance(frames, dict)
+        self.assertIsInstance(frames, list)
 
 
 class TestAggregatedStatsGetters(TestCase):


### PR DESCRIPTION
Summary of changes:

- Change `README` to reflect that we have open 360 data now.
- Bump version number.
- Add path to the JSON files in `OPEN_DATA_PATHS`.
- Add a function to `entities` which adds the match_id to the resulting 360 data, this is something the current frames function was missing. 
- Remove the exception stating there was no open 360 data. 
- Update the tests to reflect the changes made above and also change the `competition_frames()` test to use a smaller competition. 