### PR TITLE
Replace "credentials were not supplied" print message by warning

### DIFF
--- a/statsbombpy/api_client.py
+++ b/statsbombpy/api_client.py
@@ -1,3 +1,5 @@
+import warnings
+
 import requests as req
 
 from requests_cache import install_cache
@@ -10,6 +12,7 @@ from statsbombpy.config import (
     HOSTNAME,
     VERSIONS,
 )
+from statsbombpy.errors import NoAuthWarning
 
 
 install_cache(mkdtemp(), backend="sqlite", expire_after=CACHED_CALLS_SECS)
@@ -17,7 +20,7 @@ install_cache(mkdtemp(), backend="sqlite", expire_after=CACHED_CALLS_SECS)
 
 def has_auth(creds):
     if creds.get("user") in [None, ""] or creds.get("passwd") in [None, ""]:
-        print("credentials were not supplied. open data access only")
+        warnings.warn("credentials were not supplied. open data access only", NoAuthWarning)
         return False
     return True
 

--- a/statsbombpy/errors.py
+++ b/statsbombpy/errors.py
@@ -1,0 +1,3 @@
+class NoAuthWarning(UserWarning):
+    """Warning raised when no user credentials are provided."""
+    pass


### PR DESCRIPTION
When running code without credentials, the 'credentials not supplied' message
was printed to the console on each function invocation, which is very annoying
when loading a batch of data. This commit replaces the print message by a custom
``NoAuthWarning`` which the user can filter easily.

See also #2 and #21.