### PR TITLE
Add home and away managers to match dataframe output

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,8 @@ sb.matches(competition_id=9, season_id=42)
       <th>competition_stage</th>
       <th>stadium</th>
       <th>referee</th>
+      <th>home_managers</th>
+      <th>away_managers</th>
       <th>data_version</th>
       <th>shot_fidelity_version</th>
       <th>xy_fidelity_version</th>
@@ -174,6 +176,8 @@ sb.matches(competition_id=9, season_id=42)
       <td>Regular Season</td>
       <td>VELTINS-Arena</td>
       <td>F. Zwayer</td>
+      <td>David Wagner</td>
+      <td>Adi Hütter</td>
       <td>1.1.0</td>
       <td>2</td>
       <td>2</td>
@@ -195,6 +199,8 @@ sb.matches(competition_id=9, season_id=42)
       <td>Regular Season</td>
       <td>Commerzbank-Arena</td>
       <td>F. Willenborg</td>
+      <td>Adi Hütter</td>
+      <td>Friedhelm Funkel</td>      
       <td>1.1.0</td>
       <td>2</td>
       <td>2</td>
@@ -216,6 +222,8 @@ sb.matches(competition_id=9, season_id=42)
       <td>Regular Season</td>
       <td>VOLKSWAGEN ARENA</td>
       <td>F. Brych</td>
+      <td>Oliver Glasner</td>
+      <td>Marco Rose</td>      
       <td>1.1.0</td>
       <td>2</td>
       <td>2</td>
@@ -237,6 +245,8 @@ sb.matches(competition_id=9, season_id=42)
       <td>Regular Season</td>
       <td>Olympiastadion Berlin</td>
       <td>F. Willenborg</td>
+      <td>Jürgen Klinsmann</td>
+      <td>Christian Streich</td>      
       <td>1.1.0</td>
       <td>2</td>
       <td>2</td>
@@ -258,6 +268,8 @@ sb.matches(competition_id=9, season_id=42)
       <td>Regular Season</td>
       <td>Allianz Arena</td>
       <td>C. Dingert</td>
+      <td>Hans-Dieter Flick</td>
+      <td>Oliver Glasner </td>      
       <td>1.1.0</td>
       <td>2</td>
       <td>2</td>

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.3.0",
+    version="1.4.0",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -31,6 +31,26 @@ def matches(
     else:
         matches = public.matches(competition_id, season_id)
     if fmt == "dataframe":
+        home_managers = [
+            (
+                ", ".join(
+                    [m["name"] for m in matches[match]["home_team"]["managers"]]
+                    if "managers" in matches[match]["home_team"]
+                    else ""
+                )
+            )
+            for match in matches
+        ]
+        away_managers = [
+            (
+                ", ".join(
+                    [m["name"] for m in matches[match]["away_team"]["managers"]]
+                    if "managers" in matches[match]["away_team"]
+                    else ""
+                )
+            )
+            for match in matches
+        ]
         matches = pd.DataFrame(matches.values())
         matches["competition"] = matches.competition.apply(
             lambda c: f"{c['country_name']} - {c['competition_name']}"
@@ -42,6 +62,8 @@ def matches(
                 matches[col] = matches[col].apply(
                     lambda x: x["name"] if not pd.isna(x) else x
                 )
+        matches["home_managers"] = home_managers
+        matches["away_managers"] = away_managers
         metadata = matches.pop("metadata")
         for k in ["data_version", "shot_fidelity_version", "xy_fidelity_version"]:
             matches[k] = metadata.apply(lambda x: x.get(k))
@@ -181,43 +203,47 @@ def player_match_stats(
     if api_client.has_auth(creds) is True:
         player_match_stats = api_client.player_match_stats(match_id, creds=creds)
     else:
-        raise Exception("There is currently no open data for aggregated stats, please provide credentials")
+        raise Exception(
+            "There is currently no open data for aggregated stats, please provide credentials"
+        )
     if fmt == "dataframe":
         player_match_stats = pd.json_normalize(player_match_stats)
     return player_match_stats
 
 
 def player_season_stats(
-    competition_id: int, 
-    season_id: int, 
-    fmt="dataframe", 
+    competition_id: int,
+    season_id: int,
+    fmt="dataframe",
     creds: dict = DEFAULT_CREDS,
 ) -> Union[pd.DataFrame, dict]:
     if api_client.has_auth(creds) is True:
         player_season_stats = api_client.player_season_stats(
-            competition_id, 
-            season_id, 
-            creds=creds)
+            competition_id, season_id, creds=creds
+        )
     else:
-        raise Exception("There is currently no open data for aggregated stats, please provide credentials")
+        raise Exception(
+            "There is currently no open data for aggregated stats, please provide credentials"
+        )
     if fmt == "dataframe":
         player_season_stats = pd.json_normalize(player_season_stats)
     return player_season_stats
 
 
 def team_season_stats(
-    competition_id: int, 
-    season_id: int, 
-    fmt="dataframe", 
+    competition_id: int,
+    season_id: int,
+    fmt="dataframe",
     creds: dict = DEFAULT_CREDS,
 ) -> Union[pd.DataFrame, dict]:
     if api_client.has_auth(creds) is True:
         team_season_stats = api_client.team_season_stats(
-            competition_id, 
-            season_id, 
-            creds=creds)
+            competition_id, season_id, creds=creds
+        )
     else:
-        raise Exception("There is currently no open data for aggregated stats, please provide credentials")
+        raise Exception(
+            "There is currently no open data for aggregated stats, please provide credentials"
+        )
     if fmt == "dataframe":
         team_season_stats = pd.json_normalize(team_season_stats)
     return team_season_stats

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -35,6 +35,17 @@ class TestBaseGetters(TestCase):
         matches = sb.matches(competition_id=2, season_id=44, creds={})
         self.assertIsInstance(matches, pd.DataFrame)
 
+        matches = sb.matches(competition_id=11, season_id=1)
+        self.assertEquals(
+            matches.query("match_id == 9695")["home_managers"].iloc[0],
+            "Juan Rubén Uría Corral, Marcelino García Toral",
+        )
+        self.assertEquals(
+            matches.query("match_id == 9695")["away_managers"].iloc[0],
+            "Ernesto Valverde Tejedor",
+        )
+
+
     def test_lineups(self):
         lineups = sb.lineups(match_id=7562)
         self.assertIsInstance(lineups, dict)


### PR DESCRIPTION
When `matches` function in `sb.py` returns a Pandas dataframe, it now includes the `home_managers` and `away_managers` as a `str` of names. Applied black formatting as well to tidy up some of the code.

Added tests for the manager parsing in `test_sb.py`, including a case where multiple managers are present.

Added managers to the `sb.matches` example in  `README.md`.