### PR TITLE
Fix lineups function handle missing player countries

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.4.0",
+    version="1.4.1",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/api_client.py
+++ b/statsbombpy/api_client.py
@@ -1,16 +1,10 @@
-import requests as req
-
-from requests_cache import install_cache
 from tempfile import mkdtemp
 
+import requests as req
+from requests_cache import install_cache
+
 import statsbombpy.entities as ents
-
-from statsbombpy.config import (
-    CACHED_CALLS_SECS,
-    HOSTNAME,
-    VERSIONS,
-)
-
+from statsbombpy.config import CACHED_CALLS_SECS, HOSTNAME, VERSIONS
 
 install_cache(mkdtemp(), backend="sqlite", expire_after=CACHED_CALLS_SECS)
 
@@ -36,51 +30,43 @@ def get_resource(url: str, creds: dict) -> list:
 def competitions(creds: dict) -> dict:
     url = f"{HOSTNAME}/api/{VERSIONS['competitions']}/competitions"
     competitions = get_resource(url, creds)
-    competitions = ents.competitions(competitions)
-    return competitions
+    return ents.competitions(competitions)
 
 
 def matches(competition_id: int, season_id: int, creds: dict) -> dict:
     url = f"{HOSTNAME}/api/{VERSIONS['matches']}/competitions/{competition_id}/seasons/{season_id}/matches"
     matches = get_resource(url, creds)
-    matches = ents.matches(matches)
-    return matches
+    return ents.matches(matches)
 
 
 def lineups(match_id: int, creds: dict) -> dict:
     url = f"{HOSTNAME}/api/{VERSIONS['lineups']}/lineups/{match_id}"
     lineups = get_resource(url, creds)
-    lineups = ents.lineups(lineups)
-    return lineups
+    return ents.lineups(lineups)
 
 
 def events(match_id: int, creds: dict) -> dict:
     url = f"{HOSTNAME}/api/{VERSIONS['events']}/events/{match_id}"
     events = get_resource(url, creds)
-    events = ents.events(events, match_id)
-    return events
+    return ents.events(events, match_id)
 
 
-def frames(match_id: int, creds: dict) -> dict:
+def frames(match_id: int, creds: dict) -> list:
     url = f"{HOSTNAME}/api/{VERSIONS['360-frames']}/360-frames/{match_id}"
     frames = get_resource(url, creds)
-    frames = ents.frames(frames, match_id)
-    return frames
+    return ents.frames(frames, match_id)
 
 
-def player_match_stats(match_id: int, creds: dict) -> dict:
+def player_match_stats(match_id: int, creds: dict) -> list:
     url = f"{HOSTNAME}/api/{VERSIONS['player-match-stats']}/matches/{match_id}/player-stats"
-    player_match_stats = get_resource(url, creds)
-    return player_match_stats
+    return get_resource(url, creds)
 
 
-def player_season_stats(competition_id: int, season_id: int, creds: dict) -> dict:
+def player_season_stats(competition_id: int, season_id: int, creds: dict) -> list:
     url = f"{HOSTNAME}/api/{VERSIONS['player-season-stats']}/competitions/{competition_id}/seasons/{season_id}/player-stats"
-    player_season_stats = get_resource(url, creds)
-    return player_season_stats
+    return get_resource(url, creds)
 
 
-def team_season_stats(competition_id: int, season_id: int, creds: dict) -> dict:
+def team_season_stats(competition_id: int, season_id: int, creds: dict) -> list:
     url = f"{HOSTNAME}/api/{VERSIONS['team-season-stats']}/competitions/{competition_id}/seasons/{season_id}/team-stats"
-    team_season_stats = get_resource(url, creds)
-    return team_season_stats
+    return get_resource(url, creds)

--- a/statsbombpy/entities.py
+++ b/statsbombpy/entities.py
@@ -33,6 +33,7 @@ def events(events: list, match_id: int) -> dict:
         events_[ev["id"]] = ev
     return events_
 
+
 def frames(frames: list, match_id: int) -> list:
     for fr in frames:
         fr["match_id"] = match_id

--- a/statsbombpy/helpers.py
+++ b/statsbombpy/helpers.py
@@ -1,8 +1,8 @@
 from collections import defaultdict
-from joblib import Memory
 
 import inflect
 import pandas as pd
+from joblib import Memory
 
 
 def flatten_event(event, flatten_attrs):
@@ -17,8 +17,8 @@ def flatten_event(event, flatten_attrs):
     for k, v in event.copy().items():
         if isinstance(v, dict) and "name" in v:
             event[k] = v["name"]
-            if k in ['possession_team', 'player']:
-                event[f"{k}_id"] = v['id']
+            if k in ["possession_team", "player"]:
+                event[f"{k}_id"] = v["id"]
     return event
 
 
@@ -39,7 +39,7 @@ def is_relevant(event, filters):
 
 
 def reduce_events(all_events: dict, fmt: str) -> dict:
-    reduced_events = defaultdict(list)
+    reduced_events: dict = defaultdict(list)
     for events in all_events:
         for ev_type, evs in events.items():
             reduced_events[ev_type] = reduced_events.get(ev_type, []) + evs

--- a/statsbombpy/public.py
+++ b/statsbombpy/public.py
@@ -1,8 +1,6 @@
 import requests as req
-import warnings
 
 import statsbombpy.entities as ents
-
 from statsbombpy.config import OPEN_DATA_PATHS
 
 
@@ -32,6 +30,7 @@ def events(match_id: int) -> dict:
     events = req.get(OPEN_DATA_PATHS["events"].format(match_id=match_id)).json()
     events = ents.events(events, match_id)
     return events
+
 
 def frames(match_id: int) -> dict:
     frames = req.get(OPEN_DATA_PATHS["frames"].format(match_id=match_id)).json()

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -79,7 +79,7 @@ def lineups(match_id, fmt="dataframe", creds: dict = DEFAULT_CREDS):
         lineups_ = {}
         for lineup in lineups.values():
             lineup_ = pd.DataFrame(lineup["lineup"])
-            lineup_["country"] = lineup_.country.apply(lambda c: c["name"])
+            lineup_["country"] = lineup_.country.apply(lambda c: c["name"] if isinstance(c, dict) else 'Unknown')
             lineups_[lineup["team_name"]] = lineup_
             lineups = lineups_
     return lineups

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -1,10 +1,8 @@
-import pandas as pd
-import warnings
-
 from functools import partial
 from multiprocessing import Pool
-
 from typing import Union
+
+import pandas as pd
 
 from statsbombpy import api_client, public
 from statsbombpy.config import DEFAULT_CREDS, PARALLELL_CALLS_NUM
@@ -79,7 +77,9 @@ def lineups(match_id, fmt="dataframe", creds: dict = DEFAULT_CREDS):
         lineups_ = {}
         for lineup in lineups.values():
             lineup_ = pd.DataFrame(lineup["lineup"])
-            lineup_["country"] = lineup_.country.apply(lambda c: c["name"] if isinstance(c, dict) else 'Unknown')
+            lineup_["country"] = lineup_.country.apply(
+                lambda c: c["name"] if isinstance(c, dict) else "Unknown"
+            )
             lineups_[lineup["team_name"]] = lineup_
             lineups = lineups_
     return lineups
@@ -150,7 +150,7 @@ def frames(
     match_id: int,
     fmt: str = "dataframe",
     creds: dict = DEFAULT_CREDS,
-) -> Union[pd.DataFrame, dict]:
+) -> Union[pd.DataFrame, list, dict]:
     if api_client.has_auth(creds) is True:
         frames = api_client.frames(match_id, creds=creds)
     else:

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -3,6 +3,7 @@ import pandas as pd
 from unittest import TestCase, main
 
 from statsbombpy import sb
+from statsbombpy.api_client import matches
 
 
 class TestBaseGetters(TestCase):
@@ -56,6 +57,11 @@ class TestBaseGetters(TestCase):
 
         lineups = sb.lineups(match_id=7562, creds={})
         self.assertIsInstance(lineups, dict)
+
+        lineups = sb.lineups(match_id=301244)
+        self.assertEquals(
+            lineups['Stoke City']['country'].iloc[0], "England",
+        )
 
 
 class TestEventGetters(TestCase):

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -1,6 +1,6 @@
-import pandas as pd
-
 from unittest import TestCase, main
+
+import pandas as pd
 
 from statsbombpy import sb
 from statsbombpy.api_client import matches
@@ -45,7 +45,6 @@ class TestBaseGetters(TestCase):
             matches.query("match_id == 9695")["away_managers"].iloc[0],
             "Ernesto Valverde Tejedor",
         )
-
 
     def test_lineups(self):
         lineups = sb.lineups(match_id=7562)
@@ -155,7 +154,9 @@ class TestAggregatedStatsGetters(TestCase):
         player_season_stats = sb.player_season_stats(competition_id=43, season_id=3)
         self.assertIsInstance(player_season_stats, pd.DataFrame)
 
-        player_season_stats = sb.player_season_stats(competition_id=43, season_id=3, fmt="json")
+        player_season_stats = sb.player_season_stats(
+            competition_id=43, season_id=3, fmt="json"
+        )
         self.assertIsInstance(player_season_stats, list)
 
         with self.assertRaises(Exception):
@@ -164,7 +165,9 @@ class TestAggregatedStatsGetters(TestCase):
         player_season_stats = sb.player_season_stats(competition_id=2, season_id=44)
         self.assertIsInstance(player_season_stats, pd.DataFrame)
 
-        player_season_stats = sb.player_season_stats(competition_id=2, season_id=44, fmt="json")
+        player_season_stats = sb.player_season_stats(
+            competition_id=2, season_id=44, fmt="json"
+        )
         self.assertIsInstance(player_season_stats, list)
 
         with self.assertRaises(Exception):
@@ -174,7 +177,9 @@ class TestAggregatedStatsGetters(TestCase):
         team_season_stats = sb.team_season_stats(competition_id=43, season_id=3)
         self.assertIsInstance(team_season_stats, pd.DataFrame)
 
-        team_season_stats = sb.team_season_stats(competition_id=43, season_id=3, fmt="json")
+        team_season_stats = sb.team_season_stats(
+            competition_id=43, season_id=3, fmt="json"
+        )
         self.assertIsInstance(team_season_stats, list)
 
         with self.assertRaises(Exception):
@@ -183,7 +188,9 @@ class TestAggregatedStatsGetters(TestCase):
         team_season_stats = sb.team_season_stats(competition_id=2, season_id=44)
         self.assertIsInstance(team_season_stats, pd.DataFrame)
 
-        team_season_stats = sb.team_season_stats(competition_id=2, season_id=44, fmt="json")
+        team_season_stats = sb.team_season_stats(
+            competition_id=2, season_id=44, fmt="json"
+        )
         self.assertIsInstance(team_season_stats, list)
 
         with self.assertRaises(Exception):


### PR DESCRIPTION
There are a number of match ids that, when passed to the `sb.lineups` function, throw an error. This is caused by one of the players in the lineup not having country information.

This fix checks whether or not we have the player's country and assigns it as 'Unknown' if we do not.