### PR TITLE
Change matches function to include all games for a competition season

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.4.3",
+    version="1.5.0",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/entities.py
+++ b/statsbombpy/entities.py
@@ -16,7 +16,6 @@ def matches(matches: list) -> dict:
     matches_ = {
         match["match_id"]: match
         for match in matches
-        if match["match_status"] == "available"
     }
     return matches_
 

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -38,10 +38,6 @@ class TestBaseGetters(TestCase):
 
         matches = sb.matches(competition_id=11, season_id=1)
         self.assertEquals(
-            matches.query("match_id == 9695")["home_managers"].iloc[0],
-            "Juan Rubén Uría Corral, Marcelino García Toral",
-        )
-        self.assertEquals(
             matches.query("match_id == 9695")["away_managers"].iloc[0],
             "Ernesto Valverde Tejedor",
         )

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -36,6 +36,12 @@ class TestBaseGetters(TestCase):
         matches = sb.matches(competition_id=2, season_id=44, creds={})
         self.assertIsInstance(matches, pd.DataFrame)
 
+        matches = sb.matches(competition_id=3, season_id=108)
+        self.assertEquals(
+            matches.query("match_id == 3803206")["home_managers"].iloc[0],
+            "Steven Reid, Steve Cooper",
+        )
+
         matches = sb.matches(competition_id=11, season_id=1)
         self.assertEquals(
             matches.query("match_id == 9695")["away_managers"].iloc[0],


### PR DESCRIPTION
It's been pointed out that the `sb.matches()` function only returns the games we have already collected for the competition season even though the API returns all the matches for the comp-season regardless of whether they have been collected or not. 

StatsBombR also returns all matches so better to have the two aligned.

I also removed the matches test for dual managers as the particular instance has been fixed in the raw data so that test fails now.