### PR TITLE
Fix visible-area bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.5.0",
+    version="1.5.1",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -156,9 +156,8 @@ def frames(
     else:
         frames = public.frames(match_id)
     if fmt == "dataframe":
-        frames = pd.json_normalize(
-            frames, "freeze_frame", ["event_uuid", "visible_area", "match_id"]
-        )
+        frames = pd.DataFrame(frames).explode('freeze_frame')
+        frames = pd.concat([frames.drop('freeze_frame', axis=1).reset_index(drop=True), pd.json_normalize(frames.freeze_frame)], axis=1)
         frames = frames.rename(columns={"event_uuid": "id"})
     return frames
 

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -122,6 +122,9 @@ class TestFrameGetters(TestCase):
         frames = sb.frames(match_id=3788741, creds={})
         self.assertIsInstance(frames, pd.DataFrame)
 
+        frames = sb.frames(match_id=3847567, creds={})
+        self.assertIsInstance(frames, pd.DataFrame)
+
     def test_competition_frames(self):
         frames = sb.competition_frames(
             country="Europe",


### PR DESCRIPTION
- Some open data is missing visible area coordinates for its 360 frames.
- If you pull the 360 data for one of those matches using the `sb.frames()` function it returns an error:
`ValueError: operands could not be broadcast together with shape (0,) (1307,)`
- Here we modify the `sb.frames()` function so that you can still get the 360 data for open data matches that are missing visible area data.
- I also added a test to check one of the culprit matches. 