### PR TITLE
Raise exception when using 360_metrics with open_data

### DIFF
--- a/README.md
+++ b/README.md
@@ -1201,6 +1201,8 @@ grouped_events["dribbles"]
 ### 360 Metrics
 If you have access to 360 data for a competition, you can set `include_360_metrics=True` in the `events()` and `competition_events()` functions to retrieve 360 metrics such a line breaking passess together with the event data.
 
+The open data does not include the 360 metrics. This is currently only available to customers with a data subscription.
+
 ```
 events = sb.events(match_id=3837323, include_360_metrics=True)
 comp_events = sb.competition_events(

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.6.0",
+    version="1.6.1",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -99,6 +99,8 @@ def events(
     include_360_metrics=False,
 ) -> Union[pd.DataFrame, dict]:
 
+    if not api_client.has_auth(creds) and include_360_metrics:
+        raise Exception("360 metrics not available in open data")
     if api_client.has_auth(creds) is True:
         events = api_client.events(match_id, creds=creds)
     else:


### PR DESCRIPTION
360 metrics are not available in open data. 

Key changes:
 - Raise exception when attempting to retrieve 360 metrics on open data
 - Updated README to specify that open data does not include 360 metrics
 - Bumped up patch version number


