### PR TITLE
Fix missing match_id bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.6.1",
+    version="1.6.2",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/helpers.py
+++ b/statsbombpy/helpers.py
@@ -55,7 +55,6 @@ def merge_events_and_frames(
     drop_keys=[
         "event_uuid",
         "visible_area",
-        "match_id",
         "freeze_frame",
         "visible_player_counts",
         "distances_from_edge_of_visible_area",


### PR DESCRIPTION
When the user sets `include_360_metrics=True` in the `sb.events()` function we drop the `match_id`.