### PR TITLE
Fix missing team_id bug

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.6.1",
+    version="1.6.3",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/helpers.py
+++ b/statsbombpy/helpers.py
@@ -17,7 +17,7 @@ def flatten_event(event, flatten_attrs):
     for k, v in event.copy().items():
         if isinstance(v, dict) and "name" in v:
             event[k] = v["name"]
-            if k in ["possession_team", "player"]:
+            if k in ["possession_team", "player", "team"]:
                 event[f"{k}_id"] = v["id"]
     return event
 


### PR DESCRIPTION
We are dropping the `team_id` variable when using the `sb.events()` function.