### PR TITLE
Add missing dependencies

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,9 +16,15 @@ setup(
     author_email="support@statsbombservices.com",
     packages=["statsbombpy"],
     install_requires=[
-        "nose2",
         "pandas",
         "requests",
         "requests-cache",
+        "inflect",
+        "joblib",
     ],
+    extras_require={
+        'dev': [
+            "nose2",
+        ]
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.8.0",
+    version="1.8.1",
     description="Easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",


### PR DESCRIPTION
Adds the following missing dependencies to the setup script:
  - inflect
  - joblib

Removes nose2 from the required dependencies. This package is only required for running the tests. It can now be installed by running "pip install -e .[dev]"