### PR TITLE
Bump player season, match and event api version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.9.0",
+    version="1.10.0",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/config.py
+++ b/statsbombpy/config.py
@@ -32,7 +32,7 @@ VERSIONS = {
     "lineups": "v4",
     "events": "v7",
     "360-frames": "v2",
-    "player-match-stats": "v3",
-    "player-season-stats": "v3",
+    "player-match-stats": "v4",
+    "player-season-stats": "v4",
     "team-season-stats": "v2",
 }

--- a/statsbombpy/config.py
+++ b/statsbombpy/config.py
@@ -30,7 +30,7 @@ VERSIONS = {
     "competitions": "v4",
     "matches": "v5",
     "lineups": "v4",
-    "events": "v7",
+    "events": "v8",
     "360-frames": "v2",
     "player-match-stats": "v4",
     "player-season-stats": "v4",


### PR DESCRIPTION
We have released version 4.0 for both the player-match-stats API and the player-season-stats API. This change updates those numbers in statsbombpy.