### PR TITLE
Add status check to public api functions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.10.0",
+    version="1.10.1",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/public.py
+++ b/statsbombpy/public.py
@@ -4,35 +4,44 @@ import statsbombpy.entities as ents
 from statsbombpy.config import OPEN_DATA_PATHS
 
 
+def get_response(path):
+    response = req.get(path)
+    response.raise_for_status()
+    data = response.json()
+    return data
+
+
 def competitions():
-    competitions = req.get(OPEN_DATA_PATHS["competitions"]).json()
+    competitions = get_response(OPEN_DATA_PATHS["competitions"])
     competitions = ents.competitions(competitions)
     return competitions
 
 
 def matches(competition_id: int, season_id: int) -> dict:
-    matches = req.get(
-        OPEN_DATA_PATHS["matches"].format(
-            competition_id=competition_id, season_id=season_id
-        )
-    ).json()
+    path = OPEN_DATA_PATHS["matches"].format(
+        competition_id=competition_id, season_id=season_id
+    )
+    matches = get_response(path)
     matches = ents.matches(matches)
     return matches
 
 
 def lineups(match_id: int):
-    lineups = req.get(OPEN_DATA_PATHS["lineups"].format(match_id=match_id)).json()
+    path = OPEN_DATA_PATHS["lineups"].format(match_id=match_id)
+    lineups = get_response(path)
     lineups = ents.lineups(lineups)
     return lineups
 
 
 def events(match_id: int) -> dict:
-    events = req.get(OPEN_DATA_PATHS["events"].format(match_id=match_id)).json()
+    path = OPEN_DATA_PATHS["events"].format(match_id=match_id)
+    events = get_response(path)
     events = ents.events(events, match_id)
     return events
 
 
 def frames(match_id: int) -> dict:
-    frames = req.get(OPEN_DATA_PATHS["frames"].format(match_id=match_id)).json()
+    path = OPEN_DATA_PATHS["frames"].format(match_id=match_id)
+    frames = get_response(path)
     frames = ents.frames(frames, match_id)
     return frames

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -1,9 +1,8 @@
 from unittest import TestCase, main
 
 import pandas as pd
-
+from requests.exceptions import HTTPError
 from statsbombpy import sb
-from statsbombpy.api_client import matches
 
 
 class TestBaseGetters(TestCase):
@@ -42,6 +41,10 @@ class TestBaseGetters(TestCase):
             "Ernesto Valverde Tejedor",
         )
 
+        with self.assertRaises(HTTPError) as cm:
+            matches = sb.matches(competition_id=1, season_id=1, creds={})
+        self.assertEqual(cm.exception.response.status_code, 404)
+
     def test_lineups(self):
         lineups = sb.lineups(match_id=7562)
         self.assertIsInstance(lineups, dict)
@@ -58,6 +61,10 @@ class TestBaseGetters(TestCase):
             lineups["Stoke City"]["country"].iloc[0],
             "England",
         )
+
+        with self.assertRaises(HTTPError) as cm:
+            lineups = sb.lineups(match_id=1, creds={})
+        self.assertEqual(cm.exception.response.status_code, 404)
 
 
 class TestEventGetters(TestCase):
@@ -87,6 +94,10 @@ class TestEventGetters(TestCase):
         events = sb.events(match_id=3837323, include_360_metrics=True)
         self.assertIsInstance(events, pd.DataFrame)
         self.assertTrue("visible_teammates" in events.columns)
+
+        with self.assertRaises(HTTPError) as cm:
+            events = sb.events(match_id=1, creds={})
+        self.assertEqual(cm.exception.response.status_code, 404)
 
     def test_competition_events(self):
         events = sb.competition_events(
@@ -136,6 +147,10 @@ class TestFrameGetters(TestCase):
 
         frames = sb.frames(match_id=3847567, creds={})
         self.assertIsInstance(frames, pd.DataFrame)
+
+        with self.assertRaises(HTTPError) as cm:
+            frames = sb.frames(match_id=1, creds={})
+        self.assertEqual(cm.exception.response.status_code, 404)
 
     def test_competition_frames(self):
         frames = sb.competition_frames(


### PR DESCRIPTION
- Currently when a user enters the wrong match or competition and season id into the open data functions you get the following error:
`JSONDecodeError: Extra data: line 1 column 4 (char 3)`

Instead, we've added a status check to all the public API calls so that if, for example, the user passes through an invalid match_id we get a `HTTPError 404` returned to indicate that they've tried to access a resource that doesn't exist.  