### PR TITLE
Bump matches api version number

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.10.1",
+    version="1.11.0",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/config.py
+++ b/statsbombpy/config.py
@@ -28,7 +28,7 @@ else:
 
 VERSIONS = {
     "competitions": "v4",
-    "matches": "v5",
+    "matches": "v6",
     "lineups": "v4",
     "events": "v8",
     "360-frames": "v2",


### PR DESCRIPTION
We have released v6 of the 'matches in competition' API - this change bumps the version number in statsbombpy so that it hits the new version.