### PR TITLE
Fix missing pass receipt id column

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.11.0",
+    version="1.12.0",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/helpers.py
+++ b/statsbombpy/helpers.py
@@ -53,7 +53,7 @@ def flatten_event(event, flatten_attrs):
     for k, v in event.copy().items():
         if isinstance(v, dict) and "name" in v:
             event[k] = v["name"]
-            if k in ["possession_team", "player", "team"]:
+            if k in ["possession_team", "player", "team", "pass_recipient"]:
                 event[f"{k}_id"] = v["id"]
     return event
 


### PR DESCRIPTION
We're currently dropping the pass recipient id column when the events are pulled and this change fixes that.