### PR TITLE
Add exception for none type frames

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.13.0",
+    version="1.13.1",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -175,10 +175,11 @@ def frames(
     frames = _360_frames(match_id, creds)
     for frame in frames:
         if "distances_from_edge_of_visible_area" in frame:
-            for ff, d_from_vis_area in zip(
-                frame["freeze_frame"], frame["distances_from_edge_of_visible_area"]
-            ):
-                ff["distance_from_edge_of_visible_area"] = d_from_vis_area["distance"]
+            if frame["distances_from_edge_of_visible_area"] is not None:
+                for ff, d_from_vis_area in zip(
+                    frame["freeze_frame"], frame["distances_from_edge_of_visible_area"]
+                ):
+                    ff["distance_from_edge_of_visible_area"] = d_from_vis_area["distance"]
     keys = ["event_uuid", "visible_area", "match_id", "freeze_frame"]
     frames = [{key: frame[key] for key in keys} for frame in frames]
     if fmt == "dataframe":


### PR DESCRIPTION
- Currently there are some matches with frames that have the variable `distances_from_edge_of_visible_area` set to `None`.
- This causes an error when returning the frames for that match. 
- This variable should never be `None` per the data spec, however this is unlikely to be fixed in the raw data any time soon. 
- As such, we have updated the `frames()` function to handle these cases.
- We'll remove this functionality when the raw data gets fixed.