### PR TITLE
Matches function fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 Brought to you by StatsBomb, this repository is a Python package that allows users to easily stream StatsBomb data into Python using your log in credentials for the API or free data from our GitHub page. **API access is for paying customers only**
 
-**Support: support@statsbomb.com**
+**Support: [Hudl Support Form](https://support.hudl.com/s/contactsupport?language=en_US&Category=m0HVY000002iydd)**
 
 
 ## Installation Instructions

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.17.0",
+    version="1.18.0",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -81,7 +81,8 @@ def matches(
             df.columns = [c.replace(double, f"{prefix}_", 1) if c.startswith(double) else c for c in df.columns]
             return df
 
-        comp_df = _normalize_with_prefix(matches["competition"], "competition").rename(columns={"competition_name": "competition"})
+        comp_df = _normalize_with_prefix(matches["competition"], "competition")
+        comp_df["competition"] = comp_df["competition_country_name"] + " - " + comp_df["competition_name"]
         matches = matches.drop(columns=["competition"]).join(comp_df)
 
         season_df = _normalize_with_prefix(matches["season"], "season").rename(columns={"season_name": "season"})

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -50,19 +50,60 @@ def matches(
             )
             for match in matches
         ]
+
+        def _extract_manager_cols(matches_dict, team_key):
+            prefix = "home_manager" if team_key == "home_team" else "away_manager"
+            rows = []
+            for match in matches_dict.values():
+                managers = match.get(team_key, {}).get("managers", [])
+                if managers:
+                    normalized = pd.json_normalize(managers, sep="_")
+                    if len(normalized) > 1:
+                        row = {
+                            col: ", ".join(normalized[col].dropna().astype(str).tolist())
+                            for col in normalized.columns
+                        }
+                    else:
+                        row = normalized.iloc[0].to_dict()
+                else:
+                    row = {}
+                rows.append(row)
+            return pd.DataFrame(rows).add_prefix(f"{prefix}_")
+
+        home_manager_df = _extract_manager_cols(matches, "home_team")
+        away_manager_df = _extract_manager_cols(matches, "away_team")
+
         matches = pd.DataFrame(matches.values())
-        matches["competition"] = matches.competition.apply(
-            lambda c: f"{c['country_name']} - {c['competition_name']}"
-        )
-        for col in ["season", "home_team", "away_team"]:
-            matches[col] = matches[col].apply(lambda c: c[f"{col}_name"])
+
+        def _normalize_with_prefix(series, prefix):
+            df = pd.json_normalize(series.tolist(), sep="_").add_prefix(f"{prefix}_")
+            double = f"{prefix}_{prefix}_"
+            df.columns = [c.replace(double, f"{prefix}_", 1) if c.startswith(double) else c for c in df.columns]
+            return df
+
+        comp_df = _normalize_with_prefix(matches["competition"], "competition").rename(columns={"competition_name": "competition"})
+        matches = matches.drop(columns=["competition"]).join(comp_df)
+
+        season_df = _normalize_with_prefix(matches["season"], "season").rename(columns={"season_name": "season"})
+        matches = matches.drop(columns=["season"]).join(season_df)
+
+        for col in ["home_team", "away_team"]:
+            team_series = matches[col].apply(lambda t: {k: v for k, v in t.items() if k != "managers"})
+            team_df = _normalize_with_prefix(team_series, col).rename(columns={f"{col}_name": col})
+            matches = matches.drop(columns=[col]).join(team_df)
+
         for col in ["competition_stage", "stadium", "referee"]:
             if col in matches.columns:
-                matches[col] = matches[col].apply(
-                    lambda x: x["name"] if not pd.isna(x) else x
-                )
+                col_series = matches[col].apply(lambda x: x if isinstance(x, dict) else {})
+                expanded = _normalize_with_prefix(col_series, col).rename(columns={f"{col}_name": col})
+                matches = matches.drop(columns=[col]).join(expanded)
+
         matches["home_managers"] = home_managers
         matches["away_managers"] = away_managers
+        for col in home_manager_df.columns:
+            matches[col] = home_manager_df[col].values
+        for col in away_manager_df.columns:
+            matches[col] = away_manager_df[col].values
         metadata = matches.pop("metadata")
         for k in ["data_version", "shot_fidelity_version", "xy_fidelity_version"]:
             matches[k] = metadata.apply(lambda x: x.get(k))

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -54,8 +54,8 @@ class TestBaseGetters(TestCase):
         self.assertIn("away_team", matches.columns)
         self.assertFalse(matches["competition"].isna().any())
         self.assertFalse(matches["competition_name"].isna().any())
-        self.assertFalse(matches["home_team_id"].isna().all())
-        self.assertFalse(matches["away_team_id"].isna().all())
+        self.assertFalse(matches["home_team_id"].isna().any())
+        self.assertFalse(matches["away_team_id"].isna().any())
         expected_competition = (
             matches["competition_country_name"] + " - " + matches["competition_name"]
         )

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -41,6 +41,28 @@ class TestBaseGetters(TestCase):
             "Ernesto Valverde Tejedor",
         )
 
+        matches = sb.matches(competition_id=2, season_id=44, creds={})
+        self.assertFalse(
+            matches.columns.duplicated().any(),
+            "matches() returned duplicate column names",
+        )
+        self.assertIn("competition_name", matches.columns)
+        self.assertIn("competition_country_name", matches.columns)
+        self.assertIn("home_team_id", matches.columns)
+        self.assertIn("away_team_id", matches.columns)
+        self.assertIn("home_team", matches.columns)
+        self.assertIn("away_team", matches.columns)
+        self.assertFalse(matches["competition"].isna().any())
+        self.assertFalse(matches["competition_name"].isna().any())
+        self.assertFalse(matches["home_team_id"].isna().all())
+        self.assertFalse(matches["away_team_id"].isna().all())
+        expected_competition = (
+            matches["competition_country_name"] + " - " + matches["competition_name"]
+        )
+        pd.testing.assert_series_equal(
+            matches["competition"], expected_competition, check_names=False
+        )
+
         with self.assertRaises(HTTPError) as cm:
             matches = sb.matches(competition_id=1, season_id=1, creds={})
         self.assertEqual(cm.exception.response.status_code, 404)


### PR DESCRIPTION
Patch for the matches() function to make the following fields available `competition_id` `competition_country_name` `competition_name` `season_id` `home_team_id` `home_team_gender` `home_team_youth` `home_team_group` `home_team_country_id` `home_team_country_name`  `away_team_id` `away_team_gender` `away_team_youth` `away_team_group` `away_team_country_id` `away_team_country_name` `competition_stage_id` `stadium_id` `stadium_country_id` `stadium_country_name` `referee_id` `referee_country_id`	`referee_country_name` `home_manager_id` `home_manager_name` `home_manager_nickname` `home_manager_dob` `home_manager_country_id` `home_manager_country_name` `away_manager_id` `away_manager_name` `away_manager_nickname` `away_manager_dob` `away_manager_country_id` `away_manager_country_name`

Also replaced the no longer used support email address with the Hudl support contact form link.