### PR TITLE
docs: add Common Patterns section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2664,3 +2664,62 @@ sb.team_match_stats(3772072, fmt="dict")
 sb.team_season_stats(competition_id=9, season_id=42, fmt="dict")
 
 ```
+
+
+## Common Patterns
+
+### Filtering for goals
+
+StatsBomb does not have a dedicated `"Goal"` event type. Goals are encoded as
+`Shot` events where `shot_outcome == "Goal"`. Filtering on `type == "Goal"` will
+return an empty DataFrame.
+
+```python
+events = sb.events(match_id=303299, flatten_attrs=True)
+
+goals = events[
+    (events["type"] == "Shot") &
+    (events["shot_outcome"] == "Goal")
+]
+```
+
+To exclude the penalty shootout (period 5), where each kick is an isolated event
+rather than part of an open-play sequence:
+
+```python
+goals = events[
+    (events["type"] == "Shot") &
+    (events["shot_outcome"] == "Goal") &
+    (events["period"] < 5)
+]
+```
+
+### Reconstructing possession sequences
+
+Every event carries a `possession` column — an integer that increments each time
+possession changes. All events sharing the same `possession` value belong to the
+same unbroken sequence, making it the most reliable way to reconstruct the
+build-up to a goal.
+
+```python
+goal = goals.iloc[0]
+buildup = events[events["possession"] == goal["possession"]]
+```
+
+For set pieces (penalties, free kicks, corners), the kick itself opens a new
+possession sequence. The foul or challenge that earned it belongs to the prior
+sequence (`possession - 1`).
+
+```python
+prior_possession = events[events["possession"] == goal["possession"] - 1]
+```
+
+### Ordering events across periods
+
+The `timestamp` column resets to `00:00:00.000` at the start of each period.
+Sorting on `timestamp` alone will produce incorrect ordering in matches that go
+to extra time. Use `(period, timestamp)` together for reliable chronological order.
+
+```python
+events_sorted = events.sort_values(["period", "timestamp"])
+```


### PR DESCRIPTION
Adds a **Common Patterns** section to the README addressing three behaviours that are non-obvious from the data specification and consistently trip up users working with event data for the first time.

## Changes

### Filtering for goals
StatsBomb encodes goals as `Shot` events with `shot_outcome == "Goal"` — there is no `"Goal"` event type. The section shows the correct filter and how to exclude the penalty shootout (period 5), where each kick is an isolated event with no build-up sequence.

### Reconstructing possession sequences
The `possession` column increments each time possession changes. All events sharing the same value belong to the same unbroken sequence — the most reliable way to reconstruct the build-up to a goal. The section also covers set pieces, where the foul or challenge that earned the kick lives in the prior possession (`possession - 1`).

### Ordering events across periods
The `timestamp` column resets to `00:00:00.000` at the start of each period. Sorting on `timestamp` alone produces incorrect ordering in matches that go to extra time. The correct sort key is `(period, timestamp)`.

Closes #68