### PR TITLE
upgraded version number for multiple endpoints

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.18.0",
+    version="1.19.0",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/config.py
+++ b/statsbombpy/config.py
@@ -30,10 +30,10 @@ VERSIONS = {
     "competitions": "v4",
     "matches": "v6",
     "lineups": "v5",
-    "events": "v9",
+    "events": "v10",
     "360-frames": "v2",
-    "player-match-stats": "v5",
-    "player-season-stats": "v4",
+    "player-match-stats": "v6",
+    "player-season-stats": "v5",
     "team-season-stats": "v3",
     "team-match-stats": "v2",
 }


### PR DESCRIPTION
This release upgrades the API version number for the following endpoints:

player-match-stats -> v6
player-season-stats -> v5
events -> v10