### PR TITLE
get API endpoint versions from endpoint-versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open(os.path.join(os.path.abspath(os.path.dirname(__file__)), "README.md"))
 
 setup(
     name="statsbombpy",
-    version="1.21.0",
+    version="1.22.0",
     description="easily stream StatsBomb data into Python",
     long_description=README,
     long_description_content_type="text/markdown",

--- a/statsbombpy/api_client.py
+++ b/statsbombpy/api_client.py
@@ -5,11 +5,15 @@ import requests as req
 from requests_cache import install_cache
 
 import statsbombpy.entities as ents
-from statsbombpy.config import CACHED_CALLS_SECS, HOSTNAME, VERSIONS, _VERSION
+from statsbombpy.config import (API_VERSION_KEYS, CACHED_CALLS_SECS, HOSTNAME,
+                                VERSIONS, _VERSION)
 
 HEADERS = {"User-Agent": f"statsbombpy/{_VERSION}"}
 
 install_cache(mkdtemp(), backend="sqlite", expire_after=CACHED_CALLS_SECS)
+
+# session-lifetime cache; None until the first successful fetch
+_ENDPOINT_VERSIONS = None
 
 
 class NoAuthWarning(UserWarning):
@@ -38,51 +42,118 @@ def get_resource(url: str, creds: dict) -> list:
     return resp
 
 
-def competitions(creds: dict) -> dict:
-    url = f"{HOSTNAME}/api/{VERSIONS['competitions']}/competitions"
+def _fetch_endpoint_versions(creds: dict):
+    raw = get_resource(f"{HOSTNAME}/api/endpoint-versions", creds)
+    if not raw:
+        return None
+    return {
+        API_VERSION_KEYS[k]: f"v{v}"
+        for k, v in raw.items()
+        if k in API_VERSION_KEYS
+    }
+
+
+def endpoint_versions(creds: dict) -> dict:
+    """Return the live endpoint-versions map, fetched once per session.
+
+    Falls back to the hardcoded VERSIONS until a fetch succeeds, so a failed
+    or unauthenticated request never caches a bad value.
+    """
+    global _ENDPOINT_VERSIONS
+    if _ENDPOINT_VERSIONS is None:
+        _ENDPOINT_VERSIONS = _fetch_endpoint_versions(creds)
+    return _ENDPOINT_VERSIONS or VERSIONS
+
+
+def _normalize_version(version) -> str:
+    version = str(version)
+    return version if version.startswith("v") else f"v{version}"
+
+
+def resolve_version(endpoint: str, creds: dict, version=None) -> str:
+    """Resolve the API version for an endpoint.
+
+    A caller-supplied version wins (accepts "v9", 9 or "9"); otherwise the
+    live endpoint-versions map is used, falling back to VERSIONS.
+    """
+    if version is not None:
+        return _normalize_version(version)
+    return endpoint_versions(creds).get(endpoint, VERSIONS[endpoint])
+
+
+def competitions(creds: dict, version: str = None) -> dict:
+    v = resolve_version("competitions", creds, version)
+    url = f"{HOSTNAME}/api/{v}/competitions"
     competitions = get_resource(url, creds)
     return ents.competitions(competitions)
 
 
-def matches(competition_id: int, season_id: int, creds: dict) -> dict:
-    url = f"{HOSTNAME}/api/{VERSIONS['matches']}/competitions/{competition_id}/seasons/{season_id}/matches"
+def matches(
+    competition_id: int, season_id: int, creds: dict, version: str = None
+) -> dict:
+    v = resolve_version("matches", creds, version)
+    url = (
+        f"{HOSTNAME}/api/{v}/competitions/{competition_id}"
+        f"/seasons/{season_id}/matches"
+    )
     matches = get_resource(url, creds)
     return ents.matches(matches)
 
 
-def lineups(match_id: int, creds: dict) -> dict:
-    url = f"{HOSTNAME}/api/{VERSIONS['lineups']}/lineups/{match_id}"
+def lineups(match_id: int, creds: dict, version: str = None) -> dict:
+    v = resolve_version("lineups", creds, version)
+    url = f"{HOSTNAME}/api/{v}/lineups/{match_id}"
     lineups = get_resource(url, creds)
     return ents.lineups(lineups)
 
 
-def events(match_id: int, creds: dict) -> dict:
-    url = f"{HOSTNAME}/api/{VERSIONS['events']}/events/{match_id}"
+def events(match_id: int, creds: dict, version: str = None) -> dict:
+    v = resolve_version("events", creds, version)
+    url = f"{HOSTNAME}/api/{v}/events/{match_id}"
     events = get_resource(url, creds)
     return ents.events(events, match_id)
 
 
-def frames(match_id: int, creds: dict) -> list:
-    url = f"{HOSTNAME}/api/{VERSIONS['360-frames']}/360-frames/{match_id}"
+def frames(match_id: int, creds: dict, version: str = None) -> list:
+    v = resolve_version("360-frames", creds, version)
+    url = f"{HOSTNAME}/api/{v}/360-frames/{match_id}"
     frames = get_resource(url, creds)
     return ents.frames(frames, match_id)
 
 
-def player_match_stats(match_id: int, creds: dict) -> list:
-    url = f"{HOSTNAME}/api/{VERSIONS['player-match-stats']}/matches/{match_id}/player-stats"
+def player_match_stats(
+    match_id: int, creds: dict, version: str = None
+) -> list:
+    v = resolve_version("player-match-stats", creds, version)
+    url = f"{HOSTNAME}/api/{v}/matches/{match_id}/player-stats"
     return get_resource(url, creds)
 
 
-def player_season_stats(competition_id: int, season_id: int, creds: dict) -> list:
-    url = f"{HOSTNAME}/api/{VERSIONS['player-season-stats']}/competitions/{competition_id}/seasons/{season_id}/player-stats"
+def player_season_stats(
+    competition_id: int, season_id: int, creds: dict, version: str = None
+) -> list:
+    v = resolve_version("player-season-stats", creds, version)
+    url = (
+        f"{HOSTNAME}/api/{v}/competitions/{competition_id}"
+        f"/seasons/{season_id}/player-stats"
+    )
     return get_resource(url, creds)
 
 
-def team_match_stats(match_id: int, creds: dict) -> list:
-    url = f"{HOSTNAME}/api/{VERSIONS['team-match-stats']}/matches/{match_id}/team-stats"
+def team_match_stats(
+    match_id: int, creds: dict, version: str = None
+) -> list:
+    v = resolve_version("team-match-stats", creds, version)
+    url = f"{HOSTNAME}/api/{v}/matches/{match_id}/team-stats"
     return get_resource(url, creds)
 
 
-def team_season_stats(competition_id: int, season_id: int, creds: dict) -> list:
-    url = f"{HOSTNAME}/api/{VERSIONS['team-season-stats']}/competitions/{competition_id}/seasons/{season_id}/team-stats"
+def team_season_stats(
+    competition_id: int, season_id: int, creds: dict, version: str = None
+) -> list:
+    v = resolve_version("team-season-stats", creds, version)
+    url = (
+        f"{HOSTNAME}/api/{v}/competitions/{competition_id}"
+        f"/seasons/{season_id}/team-stats"
+    )
     return get_resource(url, creds)

--- a/statsbombpy/config.py
+++ b/statsbombpy/config.py
@@ -32,14 +32,31 @@ else:
     except NotImplementedError:
         MAX_CONCURRENCY = 4
 
+# Fallback endpoint versions, used when the live endpoint-versions map cannot be
+# fetched (e.g. no credentials or a request failure) or omits an endpoint.
 VERSIONS = {
     "competitions": "v4",
     "matches": "v6",
     "lineups": "v5",
-    "events": "v10",
+    "events": "v11",
     "360-frames": "v2",
-    "player-match-stats": "v7",
-    "player-season-stats": "v6",
-    "team-season-stats": "v3",
-    "team-match-stats": "v3",
+    "player-match-stats": "v8",
+    "player-season-stats": "v7",
+    "team-season-stats": "v4",
+    "team-match-stats": "v4",
+}
+
+# Maps the keys returned by {HOSTNAME}/api/endpoint-versions to the package's
+# internal endpoint names used in VERSIONS. api_player_mapping is intentionally
+# omitted as it has no corresponding endpoint in this package.
+API_VERSION_KEYS = {
+    "api_competitions": "competitions",
+    "api_matches": "matches",
+    "api_lineups": "lineups",
+    "api_events": "events",
+    "api_360_freeze_frames": "360-frames",
+    "api_player_match_stats": "player-match-stats",
+    "api_player_season_stats": "player-season-stats",
+    "api_team_season_stats": "team-season-stats",
+    "api_team_match_stats": "team-match-stats",
 }

--- a/statsbombpy/sb.py
+++ b/statsbombpy/sb.py
@@ -10,9 +10,9 @@ from statsbombpy.helpers import (filter_and_group_events,
                                  merge_events_and_frames, reduce_events)
 
 
-def competitions(fmt="dataframe", creds: dict = DEFAULT_CREDS):
+def competitions(fmt="dataframe", creds: dict = DEFAULT_CREDS, version: str = None):
     if api_client.has_auth(creds) is True:
-        competitions = api_client.competitions(creds)
+        competitions = api_client.competitions(creds, version=version)
     else:
         competitions = public.competitions()
     if fmt == "dataframe":
@@ -23,10 +23,16 @@ def competitions(fmt="dataframe", creds: dict = DEFAULT_CREDS):
 
 
 def matches(
-    competition_id: int, season_id: int, fmt="dataframe", creds: dict = DEFAULT_CREDS
+    competition_id: int,
+    season_id: int,
+    fmt="dataframe",
+    creds: dict = DEFAULT_CREDS,
+    version: str = None,
 ):
     if api_client.has_auth(creds) is True:
-        matches = api_client.matches(competition_id, season_id, creds=creds)
+        matches = api_client.matches(
+            competition_id, season_id, creds=creds, version=version
+        )
     else:
         matches = public.matches(competition_id, season_id)
     if fmt == "dataframe":
@@ -111,9 +117,11 @@ def matches(
     return matches
 
 
-def lineups(match_id, fmt="dataframe", creds: dict = DEFAULT_CREDS):
+def lineups(
+    match_id, fmt="dataframe", creds: dict = DEFAULT_CREDS, version: str = None
+):
     if api_client.has_auth(creds) is True:
-        lineups = api_client.lineups(match_id, creds=creds)
+        lineups = api_client.lineups(match_id, creds=creds, version=version)
     else:
         lineups = public.lineups(match_id)
     if fmt == "dataframe":
@@ -143,12 +151,13 @@ def events(
     flatten_attrs: bool = True,
     creds: dict = DEFAULT_CREDS,
     include_360_metrics=False,
+    version: str = None,
 ) -> Union[pd.DataFrame, dict]:
 
     if not api_client.has_auth(creds) and include_360_metrics:
         raise Exception("360 metrics not available in open data")
     if api_client.has_auth(creds) is True:
-        events = api_client.events(match_id, creds=creds)
+        events = api_client.events(match_id, creds=creds, version=version)
     else:
         events = public.events(match_id)
 
@@ -175,6 +184,7 @@ def competition_events(
     fmt: str = "dataframe",
     creds: dict = DEFAULT_CREDS,
     include_360_metrics=False,
+    version: str = None,
 ) -> Union[pd.DataFrame, dict]:
 
     c = competitions(creds=creds, fmt="dict")[country, division, season, gender]
@@ -184,6 +194,7 @@ def competition_events(
         fmt="json",
         creds=creds,
         include_360_metrics=include_360_metrics,
+        version=version,
     )
     with Pool(MAX_CONCURRENCY) as p:
         matches_events = p.map(
@@ -208,9 +219,10 @@ def competition_events(
 def _360_frames(
     match_id: int,
     creds: dict = DEFAULT_CREDS,
+    version: str = None,
 ) -> Union[pd.DataFrame, list, dict]:
     if api_client.has_auth(creds) is True:
-        frames = api_client.frames(match_id, creds=creds)
+        frames = api_client.frames(match_id, creds=creds, version=version)
     else:
         frames = public.frames(match_id)
     return frames
@@ -220,8 +232,9 @@ def frames(
     match_id: int,
     fmt: str = "dataframe",
     creds: dict = DEFAULT_CREDS,
+    version: str = None,
 ) -> Union[pd.DataFrame, list, dict]:
-    frames = _360_frames(match_id, creds)
+    frames = _360_frames(match_id, creds, version=version)
     for frame in frames:
         if "distances_from_edge_of_visible_area" in frame:
             if frame["distances_from_edge_of_visible_area"] is not None:
@@ -236,7 +249,7 @@ def frames(
         frames = pd.concat(
             [
                 frames.drop("freeze_frame", axis=1).reset_index(drop=True),
-                pd.json_normalize(frames.freeze_frame),
+                pd.json_normalize(frames.freeze_frame).reset_index(drop=True),
             ],
             axis=1,
         )
@@ -251,6 +264,7 @@ def competition_frames(
     gender: str = "male",
     fmt: str = "dataframe",
     creds: dict = DEFAULT_CREDS,
+    version: str = None,
 ) -> Union[pd.DataFrame, dict]:
 
     c = competitions(creds=creds, fmt="dict")[country, division, season, gender]
@@ -259,6 +273,7 @@ def competition_frames(
         frames,
         fmt="json",
         creds=creds,
+        version=version,
     )
     with Pool(MAX_CONCURRENCY) as p:
         competition_frames = p.map(
@@ -287,9 +302,12 @@ def player_match_stats(
     match_id: int,
     fmt: str = "dataframe",
     creds: dict = DEFAULT_CREDS,
+    version: str = None,
 ) -> Union[pd.DataFrame, dict]:
     if api_client.has_auth(creds) is True:
-        player_match_stats = api_client.player_match_stats(match_id, creds=creds)
+        player_match_stats = api_client.player_match_stats(
+            match_id, creds=creds, version=version
+        )
     else:
         raise Exception(
             "There is currently no open data for aggregated stats, please provide credentials"
@@ -304,10 +322,11 @@ def player_season_stats(
     season_id: int,
     fmt="dataframe",
     creds: dict = DEFAULT_CREDS,
+    version: str = None,
 ) -> Union[pd.DataFrame, dict]:
     if api_client.has_auth(creds) is True:
         player_season_stats = api_client.player_season_stats(
-            competition_id, season_id, creds=creds
+            competition_id, season_id, creds=creds, version=version
         )
     else:
         raise Exception(
@@ -322,9 +341,12 @@ def team_match_stats(
     match_id: int,
     fmt: str = "dataframe",
     creds: dict = DEFAULT_CREDS,
+    version: str = None,
 ) -> Union[pd.DataFrame, dict]:
     if api_client.has_auth(creds) is True:
-        team_match_stats = api_client.team_match_stats(match_id, creds=creds)
+        team_match_stats = api_client.team_match_stats(
+            match_id, creds=creds, version=version
+        )
     else:
         raise Exception(
             "There is currently no open data for aggregated stats, please provide credentials"
@@ -339,10 +361,11 @@ def team_season_stats(
     season_id: int,
     fmt="dataframe",
     creds: dict = DEFAULT_CREDS,
+    version: str = None,
 ) -> Union[pd.DataFrame, dict]:
     if api_client.has_auth(creds) is True:
         team_season_stats = api_client.team_season_stats(
-            competition_id, season_id, creds=creds
+            competition_id, season_id, creds=creds, version=version
         )
     else:
         raise Exception(

--- a/tests/statsbombpy_test/test_sb.py
+++ b/tests/statsbombpy_test/test_sb.py
@@ -1,8 +1,10 @@
 from unittest import TestCase, main
+from unittest.mock import patch
 
 import pandas as pd
 from requests.exceptions import HTTPError
-from statsbombpy import sb
+from statsbombpy import api_client, sb
+from statsbombpy.config import DEFAULT_CREDS, VERSIONS
 
 
 class TestBaseGetters(TestCase):
@@ -261,6 +263,57 @@ class TestAggregatedStatsGetters(TestCase):
 
         with self.assertRaises(Exception):
             sb.team_season_stats(competition_id=2, season_id=44, creds={})
+
+
+class TestEndpointVersions(TestCase):
+    def setUp(self):
+        # reset the session cache so each test controls the fetch
+        api_client._ENDPOINT_VERSIONS = None
+
+    def tearDown(self):
+        api_client._ENDPOINT_VERSIONS = None
+
+    def test_endpoint_versions_live(self):
+        versions = api_client.endpoint_versions(DEFAULT_CREDS)
+        self.assertIsInstance(versions, dict)
+        self.assertTrue(set(versions).issubset(set(VERSIONS)))
+        for value in versions.values():
+            self.assertTrue(value.startswith("v"))
+
+    def test_fetched_once_per_session(self):
+        raw = {"api_events": 10, "api_competitions": 4}
+        with patch.object(
+            api_client, "get_resource", return_value=raw
+        ) as mocked:
+            first = api_client.endpoint_versions(DEFAULT_CREDS)
+            second = api_client.endpoint_versions(DEFAULT_CREDS)
+        self.assertEqual(mocked.call_count, 1)
+        self.assertEqual(first, {"events": "v10", "competitions": "v4"})
+        self.assertIs(first, second)
+
+    def test_resolve_version_override(self):
+        self.assertEqual(
+            api_client.resolve_version("events", DEFAULT_CREDS, version="v9"),
+            "v9",
+        )
+        self.assertEqual(
+            api_client.resolve_version("events", DEFAULT_CREDS, version=9),
+            "v9",
+        )
+        self.assertEqual(
+            api_client.resolve_version("events", DEFAULT_CREDS, version="9"),
+            "v9",
+        )
+
+    def test_falls_back_to_hardcoded_versions(self):
+        with patch.object(api_client, "get_resource", return_value=[]):
+            versions = api_client.endpoint_versions(DEFAULT_CREDS)
+        self.assertIs(versions, VERSIONS)
+
+    def test_events_with_version_override(self):
+        events = sb.events(match_id=7562, version="v10")
+        self.assertIsInstance(events, pd.DataFrame)
+        self.assertFalse(events.empty)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
This PR uses the /api/endpoint-versions endpoint for API versioning so that the package is automatically in sync with the API. Previously, endpoint versions were hardcoded in config.py and required manually updating after each update to the API.

Changes:

* api_client.endpoint_versions() fetches the current version numbers with the first call made and caches it for the session
* All functions now accept an optional version parameter to override the automatic version
* API_VERSION_KEYS added to config.py to map the API's response keys to the package's internal endpoint names
* Existing VERSIONS kept incase a fallback is required, updated hardcoded versions to current values
* Minor change to fix index misalignment in frames() when concatenating 360 freeze frame data with pd.concat()
* Bump package version to 1.22.0